### PR TITLE
Minify parcel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
     "sanctuary": "^3.1.0",
     "typescript": "^4.8.3"
   },
+  "targets": {
+    "main": {
+      "optimize":true
+    }
+  },
   "scripts": {
     "dev": "yarn ts-node",
     "build": "yarn parcel build ./src/index.ts",


### PR DESCRIPTION
Parcel build was not minifying the build. Turns out we had to add some extra keys to package.json. (via: 
https://github.com/parcel-bundler/parcel/issues/7077#issuecomment-943432991)

- Fixes #5 
