### PR TITLE
Change pagination in list deployments and fix spacing bug

### DIFF
--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -1,27 +1,26 @@
 import { get } from "./utils/fetch";
 import { endpointMap } from "./common";
 import { DeploymentList } from "./types/deployment";
+import { PaginationParameters } from "./utils/pagination";
 
 type ListDeploymentsParams = {
   app?: string;
   from?: number;
-  limit?: number;
   projectId?: string;
   rollbackCandidate: boolean;
   since?: number;
   state?:
     | "BUILDING"
-    | " ERROR"
+    | "ERROR"
     | "INITIALIZING"
-    | " QUEUED"
+    | "QUEUED"
     | "READY"
     | "CANCELED";
   target?: string;
   teamId?: string;
   to?: number;
-  until?: number;
   users?: string;
-};
+} & PaginationParameters;
 
 export const listDeployments = (params?: ListDeploymentsParams) => {
   return get<DeploymentList>(endpointMap.listDeployments, {

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -1,26 +1,6 @@
 import { get } from "./utils/fetch";
 import { endpointMap } from "./common";
-import { DeploymentList } from "./types/deployment";
-import { PaginationParameters } from "./utils/pagination";
-
-type ListDeploymentsParams = {
-  app?: string;
-  from?: number;
-  projectId?: string;
-  rollbackCandidate: boolean;
-  since?: number;
-  state?:
-    | "BUILDING"
-    | "ERROR"
-    | "INITIALIZING"
-    | "QUEUED"
-    | "READY"
-    | "CANCELED";
-  target?: string;
-  teamId?: string;
-  to?: number;
-  users?: string;
-} & PaginationParameters;
+import { DeploymentList, ListDeploymentsParams } from "./types/deployment";
 
 export const listDeployments = (params?: ListDeploymentsParams) => {
   return get<DeploymentList>(endpointMap.listDeployments, {

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -1,4 +1,24 @@
 import { Pagination } from "./pagination";
+import { PaginationParameters } from "./pagination";
+
+export type ListDeploymentsParams = {
+  app?: string;
+  from?: number;
+  projectId?: string;
+  rollbackCandidate: boolean;
+  since?: number;
+  state?:
+    | "BUILDING"
+    | "ERROR"
+    | "INITIALIZING"
+    | "QUEUED"
+    | "READY"
+    | "CANCELED";
+  target?: string;
+  teamId?: string;
+  to?: number;
+  users?: string;
+} & PaginationParameters;
 
 export interface DeploymentList {
   pagination: Pagination;


### PR DESCRIPTION
Going forward, if we see "limit", and "until" in query params of any API endpoint on Vercel, we have to remember to include PaginationParams in the type and exclude limit and until from the other type definition for query.

Also, this listDeployments function had spacing in the string enums which I missed checking in the PR. Fixed that as well.
